### PR TITLE
Use `ubuntu-upstart` as base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu-upstart:trusty
 
 MAINTAINER Vladimir Blaskov <blaskov@gmail.com>
 


### PR DESCRIPTION
Until now we've been using `ubuntu` as base image, but some projects need Upstart to be properly configured on the containers and that's why we're migrating towards `ubuntu-upstart`.